### PR TITLE
Correct product name casing in "Vode" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
       <div id="Vode">
          <p class="Naslov">Vode<span class="English"> | Water</span></p>
          <hr class="lineCategory" />
-         <p class="Items">Voda Voda 0,33l <span class="money">180 RSD</span></p>
+         <p class="Items">VODA VODA 0,33l <span class="money">180 RSD</span></p>
          <hr class="line" />
          <p class="Items">Knjaz Miloš 0,25l <span class="money">180 RSD</span></p>
          <hr class="line" />


### PR DESCRIPTION
Updated the casing of "Voda Voda" to "VODA VODA" for consistency with branding. This ensures uniform presentation of product names across the website.